### PR TITLE
fix typo on oauth and perms, users.profile:read

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pull Reminders requires a Slack app in order to post messages. Follow the steps 
     identity.basic
     identity.email
     identity.team
-    user.profile:read
+    users.profile:read
     team:read
     ```
 


### PR DESCRIPTION
not sure if this was a typo or slack changed it.